### PR TITLE
Fix typos

### DIFF
--- a/mekarpeles/templates/essays/philosophy/on-friendship.html
+++ b/mekarpeles/templates/essays/philosophy/on-friendship.html
@@ -88,15 +88,15 @@ these people as some degree of mentors.
 ** How to Make Friends
 
 *** Strategies & Heuristics
-Life is short and we become more like those we spend out time with,
+Life is short and we become more like those we spend our time with,
 thus I treat the process seriously and filter my friends. Perhaps some
-may call this being too risk adverse. I actually think it's the
+may call this being too risk averse. I actually think it's the
 opposite: it's similar to a comparison of a depth first (this
 strategy; filtering friends) versus breadth first search (being
 friends with anyone no filter). DFS is provably incomplete and is thus
 in some abstract sense riskier. Granted my actual search is more
 heuristic graph search than DFS, the point stands that BFS traversal
-has desirable properties, albeit potentially diabilitating
+has desirable properties, albeit potentially debilitating
 consequences. There's nothing wrong with employing a different
 strategy. Put some thought into understanding the advantages and
 disadvantages of each and have mechanisms for mitigating worst-case
@@ -137,7 +137,7 @@ conversations, and great recommendations + resources.
     [2] http://michaelkarpeles.com/math.html
 
 *** Start With Your Peculiarities
-It's important to understand your own pecuiliaries. I have
+It's important to understand your own peculiarities. I have
 peculiarities which may not resonate with most people (and which I may
 hide from them -- especially around those with whom I am less
 comfortable). With people I know well, my interactions are less
@@ -155,15 +155,15 @@ there as being things the world needs, human rights the world deserves
 intense depression because I don't feel I have the right to be happy
 until others have the same access to organized information as someone
 as privileged as myself. There are people who can't accomplish their
-live goals, not because of their abilities, but because of their
+live goals, not because of their abilities, but because of the
 consequence of their birth. And that burden, that reality, is
-something I can't bare to ignore. It really hurts.
+something I can't bear to ignore. It really hurts.
 
 It is difficult to find people who genuinely respect and appreciate
 these sentiments -- and who wants to be around someone who doesn't
 respect who you are? I psychologically have a hard time escaping a
 "work" mindset because I don't view work as work. To me, there's just
-"life". Problems which are worth solving.  I live a fairly intentional
+"life". Problems which are worth solving. I live a fairly intentional
 life which I aspire to craft around learning and applying knowledge. I
 often slip and am ineffective at this goal, but nonetheless I am
 hypocritically dogmatic and resolute; to my fault, I am impatient with
@@ -181,9 +181,9 @@ the role of balance and try to be more accommodating on this front.
 **** Towards Improvement: Objectivity, Criticism, Accountability
 
 I want my friendships to push me, to keep me accountable, to help me
-grow and mature, be more accountable and informed. To make me more
-thoughtful, to question me, to make me more honest, more humble (this
-last one sure is low hanging fruit...)
+grow and mature, be more informed. To make me more thoughtful, to 
+question me, to make me more honest, more humble (this last one sure 
+is low hanging fruit...)
 
 **** Connecting the dots
 


### PR DESCRIPTION
Predominantly spelling.  In the "Towards Improvement: Objectivity, Criticism, Accountability" section, removes duplicate instance of "accountable"