### PR TITLE
Fix email link

### DIFF
--- a/mekarpeles/templates/infobox.html
+++ b/mekarpeles/templates/infobox.html
@@ -20,7 +20,7 @@
     </tr>
     <tr id="contact">
       <th>Email</th>
-      <td><a href="hi@mek.fyi">hi@mek.fyi</a></td>
+      <td><a href="mailto:hi@mek.fyi">hi@mek.fyi</a></td>
     </tr>
     <tr>
       <th>Github</th>


### PR DESCRIPTION
Currently redirects to https://michaelkarpeles.com/hi@mek.fyi